### PR TITLE
Implement frontend for molecule diagrams

### DIFF
--- a/src/components/panels/DiagramInputPanel.tsx
+++ b/src/components/panels/DiagramInputPanel.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { generateMoleculeDiagram } from '@/services/api';
+import { DiagramPlan, DiagramPromptRequest } from '@/types';
+
+interface DiagramInputPanelProps {
+  onDiagramUpdate: (image: string, plan: DiagramPlan) => void;
+  onLoadingChange?: (isLoading: boolean) => void;
+}
+
+const DiagramInputPanel: React.FC<DiagramInputPanelProps> = ({
+  onDiagramUpdate,
+  onLoadingChange,
+}) => {
+  const [prompt, setPrompt] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!prompt.trim()) return;
+    setIsLoading(true);
+    onLoadingChange?.(true);
+    setError(null);
+    const request: DiagramPromptRequest = { prompt };
+    try {
+      const response = await generateMoleculeDiagram(request);
+      onDiagramUpdate(response.diagram_image, response.diagram_plan);
+    } catch (err: any) {
+      setError(err.message || 'Failed to generate diagram');
+    } finally {
+      setIsLoading(false);
+      onLoadingChange?.(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <textarea
+        className="w-full p-2 rounded bg-gray-800 text-gray-100"
+        rows={4}
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Describe a molecular diagram..."
+      />
+      <button
+        className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-2"
+        onClick={handleSubmit}
+        disabled={isLoading}
+      >
+        {isLoading ? 'Generating...' : 'Submit'}
+      </button>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+};
+
+export default DiagramInputPanel;

--- a/src/components/panels/DiagramViewer.tsx
+++ b/src/components/panels/DiagramViewer.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { DiagramPlan } from '@/types';
+
+interface DiagramViewerProps {
+  isLoading?: boolean;
+  diagramImage?: string;
+  diagramPlan?: DiagramPlan;
+}
+
+const DiagramViewer: React.FC<DiagramViewerProps> = ({
+  isLoading = false,
+  diagramImage,
+  diagramPlan,
+}) => {
+  return (
+    <div className="w-full h-full flex flex-col gap-2 overflow-auto p-2">
+      {isLoading && <p>Loading...</p>}
+      {!isLoading && diagramImage && (
+        <div className="w-full" dangerouslySetInnerHTML={{ __html: diagramImage }} />
+      )}
+      {!isLoading && !diagramImage && (
+        <p className="text-sm text-gray-500">No diagram generated.</p>
+      )}
+      {diagramPlan && (
+        <details className="mt-2 text-xs whitespace-pre-wrap">
+          <summary className="cursor-pointer">Plan (debug)</summary>
+          <pre>{JSON.stringify(diagramPlan, null, 2)}</pre>
+        </details>
+      )}
+    </div>
+  );
+};
+
+export default DiagramViewer;

--- a/src/pages/molecule-diagram.tsx
+++ b/src/pages/molecule-diagram.tsx
@@ -1,0 +1,47 @@
+import type { NextPage } from 'next';
+import React, { useState } from 'react';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+import { LayoutWrapper } from '@/components/layout/LayoutWrapper';
+import DiagramInputPanel from '@/components/panels/DiagramInputPanel';
+import DiagramViewer from '@/components/panels/DiagramViewer';
+import { DiagramPlan } from '@/types';
+
+const MoleculeDiagramPage: NextPage = () => {
+  const [diagramImage, setDiagramImage] = useState<string | null>(null);
+  const [diagramPlan, setDiagramPlan] = useState<DiagramPlan | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDiagramUpdate = (image: string, plan: DiagramPlan) => {
+    setDiagramImage(image);
+    setDiagramPlan(plan);
+  };
+
+  return (
+    <div className="app-container">
+      <Header onOpenTimeMachine={() => {}} onSettingsChange={() => {}} />
+      <main className="main-content">
+        <LayoutWrapper>
+          <div className="panels-container">
+            <div className="input-panel-container">
+              <DiagramInputPanel
+                onDiagramUpdate={handleDiagramUpdate}
+                onLoadingChange={setIsLoading}
+              />
+            </div>
+            <div className="molecule-viewer-container">
+              <DiagramViewer
+                isLoading={isLoading}
+                diagramImage={diagramImage ?? undefined}
+                diagramPlan={diagramPlan ?? undefined}
+              />
+            </div>
+          </div>
+        </LayoutWrapper>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default MoleculeDiagramPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,4 +57,45 @@ export interface ModelInfo {
   categories: string[];
   context_length: number;
   is_default: boolean;
-} 
+}
+
+export interface MoleculePlacement {
+  molecule: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  label?: string;
+  label_position?: 'above' | 'below' | 'left' | 'right';
+}
+
+export interface Arrow {
+  start: number[];
+  end: number[];
+  style: 'straight' | 'curved';
+  text?: string;
+}
+
+export interface DiagramPromptRequest {
+  prompt: string;
+  canvas_width?: number;
+  canvas_height?: number;
+  model?: string;
+  preferred_model_category?: string;
+}
+
+export interface DiagramPlan {
+  plan: string;
+  molecule_list: MoleculePlacement[];
+  arrows?: Arrow[];
+  canvas_width?: number;
+  canvas_height?: number;
+}
+
+export interface DiagramResponse {
+  diagram_image: string;
+  diagram_plan: DiagramPlan;
+  status: 'completed' | 'failed' | 'processing';
+  job_id?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- create Molecule Diagram page
- add DiagramInputPanel and DiagramViewer components
- add diagram-related types
- support generateMoleculeDiagram API helper

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*
- `npm run format`